### PR TITLE
알림 수정

### DIFF
--- a/lawmaking/src/main/java/com/everyones/lawmaking/domain/entity/ColumnEventType.java
+++ b/lawmaking/src/main/java/com/everyones/lawmaking/domain/entity/ColumnEventType.java
@@ -11,19 +11,19 @@ import java.util.List;
 @Getter
 public enum ColumnEventType {
     RP_INSERT("rp_insert",
-            "representativeproposer",
+            "RepresentativeProposer",
             null,
             EventType.INSERT,
             List.of("congressman_id","bill_id")),
     BILL_STAGE_UPDATE(
             "bill_stage_update",
-            "bill",
+            "Bill",
             "stage",
             EventType.UPDATE,
             List.of("bill_id", "bill_name", "proposers", "stage")),
     CONGRESSMAN_PARTY_UPDATE(
             "congressman_party_update",
-            "congressman",
+            "Congressman",
             "party_id",
             EventType.UPDATE,
             List.of("congressman_id", "party_id", "name"));


### PR DESCRIPTION
### 내용
1-1.글자와 바이너리 부분을 바이트코드로 변환하는 코드를 제거
1-2날짜와 같은 숫자 데이터를 Long으로 변환시키는 부분도 제거
로컬에서는 해당 코드가 동작이 됐지만 mysql의 설정이 다른 부분때문에 원격에서 해당 코드를 삭제
1-3.필요없는 로그 및 필요한 운영로그를 debug로그로 변경

2.컬럼이벤트타입 클래스의 테이블 명 대소문자 구분시킴
테이블이름이 대소문자 구분해야 메타데이터에서 가져오는 대소문자 구분되는 테이블이름을 제대로 매핑시켜줄수가 있음